### PR TITLE
feat: setting페이지 select 기능 구현

### DIFF
--- a/src/components/PositionSettingCard/index.module.css
+++ b/src/components/PositionSettingCard/index.module.css
@@ -1,0 +1,3 @@
+.isDisabled {
+  @apply hidden;
+}

--- a/src/components/PositionSettingCard/index.tsx
+++ b/src/components/PositionSettingCard/index.tsx
@@ -1,5 +1,8 @@
+import clsx from 'clsx';
+
 import { H3, H4 } from '../Text';
 
+import style from '@/components/PositionSettingCard/index.module.css';
 import { MemberProps, SelectedMemberStore } from '@/store/store';
 
 const PositionSettingCard = ({ id, name, groupName, squreImageUrl, isCenter }: MemberProps) => {
@@ -12,6 +15,28 @@ const PositionSettingCard = ({ id, name, groupName, squreImageUrl, isCenter }: M
     console.log(centerUpdateMembers);
     setSelectedMembers(centerUpdateMembers);
   };
+
+  const onPositionChange = (value: string) => {
+    console.log(value);
+    const positionUpdateMembers = [...selectedMembers].map((item) => {
+      return item.id === id ? { ...item, position: value } : item;
+    });
+    console.log(positionUpdateMembers);
+    setSelectedMembers(positionUpdateMembers);
+  };
+
+  const positionArr = [
+    '메인보컬',
+    '리드보컬',
+    '서브보컬',
+    '메인댄서',
+    '리드댄서',
+    '메인래퍼',
+    '리드래퍼',
+    '서브래퍼',
+    '올라운더',
+    '프로듀서',
+  ];
 
   return (
     <div className="flex w-full">
@@ -34,8 +59,26 @@ const PositionSettingCard = ({ id, name, groupName, squreImageUrl, isCenter }: M
           </div>
         </div>
         <H4>{groupName}</H4>
-        <select>
-          <option value="메인보컬">메인보컬</option>
+        <select
+          defaultValue=""
+          onChange={(e) => {
+            onPositionChange(e.currentTarget.value);
+          }}
+        >
+          <option value="" className={clsx(style.isDisabled)} disabled>
+            포지션을 선택해주세요
+          </option>
+          {positionArr.map((item) => (
+            <option
+              key={item}
+              value={item}
+              className={clsx({
+                [style.isDisabled]: selectedMembers.some((member) => member.position === item),
+              })}
+            >
+              {item}
+            </option>
+          ))}
         </select>
       </div>
     </div>

--- a/src/components/PositionSettingCard/index.tsx
+++ b/src/components/PositionSettingCard/index.tsx
@@ -12,16 +12,13 @@ const PositionSettingCard = ({ id, name, groupName, squreImageUrl, isCenter }: M
     const centerUpdateMembers = [...selectedMembers].map((item) => {
       return item.id === id ? { ...item, isCenter: !item.isCenter } : { ...item, isCenter: false };
     });
-    console.log(centerUpdateMembers);
     setSelectedMembers(centerUpdateMembers);
   };
 
   const onPositionChange = (value: string) => {
-    console.log(value);
     const positionUpdateMembers = [...selectedMembers].map((item) => {
       return item.id === id ? { ...item, position: value } : item;
     });
-    console.log(positionUpdateMembers);
     setSelectedMembers(positionUpdateMembers);
   };
 

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -9,6 +9,7 @@ export interface MemberProps {
   debutDate: string;
   isSelected?: boolean;
   isCenter?: boolean;
+  position?: string;
 }
 
 interface MembersProps {


### PR DESCRIPTION
## 📍 주요 변경사항
![image](https://user-images.githubusercontent.com/82137004/192157745-ee71dc87-35d2-426d-9d4a-49e8484a7134.png)

select로 각 멤버별 포지션을 설정해줄 수 있음
포지션 선택시 SelectedMemberStore에 position: {선택한 포지션}이 추가됨.
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분
![image](https://user-images.githubusercontent.com/82137004/192158035-bb17d37f-93c0-4209-96bc-1f3fadc2c44b.png)

이미 다른 멤버가 차지한 포지션은 option에서 보이지 않도록 css로 display속성 none 설정
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->