### PR TITLE
feat: 뒤로가기 시 members 상태 유지하기 위해 조건부 fetch

### DIFF
--- a/src/pages/casting.tsx
+++ b/src/pages/casting.tsx
@@ -10,12 +10,14 @@ import MemberCardList from '@/components/MemberCardList';
 import SelectedMemberCardList from '@/components/SelectedMemberCardList';
 
 const Casting: NextPage = () => {
-  const { setMembers } = MemberStore();
+  const { members, setMembers } = MemberStore();
 
   useEffect(() => {
-    fetch('/data/mockdata.json')
-      .then((res) => res.json())
-      .then((res) => setMembers(res));
+    members.length > 0
+      ? null
+      : fetch('/data/mockdata.json')
+          .then((res) => res.json())
+          .then((res) => setMembers(res));
   }, []);
 
   return (


### PR DESCRIPTION
## 📍 주요 변경사항

뒤로가기할 경우에도 members를 초기화하지 않기 위해 members의 길이가 0보다 크면 fetch하지 않습니다.
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->