### PR TITLE
feat: casting page 무한스크롤 구현

### DIFF
--- a/src/apis/getMembers.ts
+++ b/src/apis/getMembers.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { BASE_URL } from '@/constants/url';
+
+const getMembers = async (query: number) => {
+  try {
+    const response = await axios.get(`${BASE_URL}/api/member/page?pageNo=${query}`);
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export default getMembers;

--- a/src/apis/getSearchedMembers.ts
+++ b/src/apis/getSearchedMembers.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import { BASE_URL } from '@/constants/url';
 
-const getSearchedMembers = async (query) => {
+const getSearchedMembers = async (query: string) => {
   try {
     const response = await axios.get(`${BASE_URL}/api/member/search?key=${query}`);
     return response.data;

--- a/src/components/MemberCardList/index.tsx
+++ b/src/components/MemberCardList/index.tsx
@@ -23,7 +23,6 @@ const MemberCardList = () => {
   const obsHandler = useCallback((entries: IntersectionObserverEntry[]) => {
     const target = entries[0];
     if (!isLoading && target.isIntersecting && preventRef.current) {
-      console.log('불러오기');
       preventRef.current = false;
       setPage((prev) => prev + 1);
     }

--- a/src/components/MemberCardList/index.tsx
+++ b/src/components/MemberCardList/index.tsx
@@ -1,16 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
 import MemberCard from '../MemberCard';
 
-import { MemberStore, SearchedMemberStore } from '@/store/store';
+import { MemberProps, MemberStore, SearchedMemberStore, SelectedMemberStore } from '@/store/store';
+import getMembers from '@/apis/getMembers';
 
 const MemberCardList = () => {
-  const { members } = MemberStore();
   const { searchedMembers } = SearchedMemberStore();
+  const { selectedMembers } = SelectedMemberStore();
+  const { members, setMembers, loadMembers } = MemberStore();
+  const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const preventRef = useRef(true);
+  const obsRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      setMembers([]);
+    };
+  }, []);
+
+  const obsHandler = useCallback((entries: IntersectionObserverEntry[]) => {
+    const target = entries[0];
+    if (!isLoading && target.isIntersecting && preventRef.current) {
+      console.log('불러오기');
+      preventRef.current = false;
+      setPage((prev) => prev + 1);
+    }
+  }, []);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(obsHandler, { threshold: 1 });
+    if (obsRef.current) {
+      observer.observe(obsRef.current);
+    }
+  }, [obsRef.current]);
+
+  const get = useCallback(async () => {
+    setIsLoading(true);
+    const res = await getMembers(page);
+
+    if (selectedMembers.length > 0) {
+      const update = res.map((item: MemberProps) =>
+        selectedMembers.some((member) => member.memberId === item.memberId)
+          ? selectedMembers.find((member) => member.memberId === item.memberId)
+          : item,
+      );
+      loadMembers(update);
+    } else {
+      loadMembers(res);
+    }
+    preventRef.current = true;
+    setIsLoading(false);
+  }, [page]);
+
+  useEffect(() => {
+    get();
+  }, [page]);
 
   return (
     <div className="flex flex-wrap gap-3">
-      {searchedMembers.length > 0
-        ? searchedMembers.map((item) => <MemberCard key={item?.memberId} {...item} />)
-        : members.map((item) => <MemberCard key={item.memberId} {...item} />)}
+      {searchedMembers.length > 0 ? (
+        searchedMembers.map((item) => <MemberCard key={item?.memberId} {...item} />)
+      ) : (
+        <>
+          {members.map((item) => (
+            <MemberCard key={item.memberId} {...item} />
+          ))}
+          <div ref={obsRef}>{searchedMembers.length === 0 ? 'loading' : null}</div>
+        </>
+      )}
     </div>
   );
 };

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -8,7 +8,7 @@ const Search = () => {
   const [searchText, setSearchText] = useState('');
   const [debouncedValue, setDebouncedValue] = useState('');
   const { setSearchedMembers } = SearchedMemberStore();
-  const { selectedMembers, setSelectedMembers } = SelectedMemberStore();
+  const { selectedMembers } = SelectedMemberStore();
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/src/pages/casting.tsx
+++ b/src/pages/casting.tsx
@@ -1,25 +1,13 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import { useEffect } from 'react';
 import Link from 'next/link';
 
 import Search from '@/components/Search/index';
 import Button from '@/components/Button';
-import { MemberStore } from '@/store/store';
 import MemberCardList from '@/components/MemberCardList';
 import SelectedMemberCardList from '@/components/SelectedMemberCardList';
 
 const Casting: NextPage = () => {
-  const { members, setMembers } = MemberStore();
-
-  useEffect(() => {
-    members.length > 0
-      ? null
-      : fetch('/data/mockdata.json')
-          .then((res) => res.json())
-          .then((res) => setMembers(res));
-  }, []);
-
   return (
     <div>
       <Head>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -15,6 +15,7 @@ export interface MemberProps {
 interface MembersProps {
   members: MemberProps[];
   setMembers: (members: MemberProps[]) => void;
+  loadMembers: (members: MemberProps[]) => void;
 }
 
 interface SearchedMemberStore {
@@ -30,6 +31,8 @@ interface SelectedMembersProps {
 export const MemberStore = create<MembersProps>((set) => ({
   members: [],
   setMembers: (members) => set({ members: members }),
+  loadMembers: (newMembers: MemberProps[]) =>
+    set((state) => ({ members: [...state.members, ...newMembers] })),
 }));
 
 export const SearchedMemberStore = create<SearchedMemberStore>((set) => ({


### PR DESCRIPTION
## 📍 주요 변경사항
![Monosnap screencast 2022-10-06 02-54-34](https://user-images.githubusercontent.com/82137004/194128894-06cdfdc9-ecc2-41e7-87f3-c68e3e18a103.gif)

Intersection Observer API 사용하여 무한스크롤 구현
- 최하단 loading div가 뷰포트에 들어오면 다음 페이지 api 호출
- 검색 시 검색결과만 노출
- 다른 페이지 방문 후 재방문 시 선택된 멤버 데이터 유지하기 위해 api호출 직후 selectedMembers 데이터와 비교하여 isSelected값을 포함시켜줌
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->