### PR TITLE
feat: setting페이지에서 그룹명과 그룹설명을 저장하는 store 생성

### DIFF
--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -1,7 +1,20 @@
 import style from '@/components/Input/index.module.css';
+import { DebutGroupStore } from '@/store/store';
 
 const Input = () => {
-  return <input className={style.groupNameInput} />;
+  const { debutGroup, setDebutGroupName } = DebutGroupStore();
+
+  const onInputChange = (e: React.FormEvent<HTMLInputElement>) => {
+    const {
+      currentTarget: { value },
+    } = e;
+    setDebutGroupName(value);
+    console.log(debutGroup);
+  };
+
+  return (
+    <input className={style.groupNameInput} value={debutGroup.groupName} onChange={onInputChange} />
+  );
 };
 
 export default Input;

--- a/src/components/Input/index.tsx
+++ b/src/components/Input/index.tsx
@@ -9,7 +9,6 @@ const Input = () => {
       currentTarget: { value },
     } = e;
     setDebutGroupName(value);
-    console.log(debutGroup);
   };
 
   return (

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -13,7 +13,7 @@ const Search = () => {
   useEffect(() => {
     const timer = setTimeout(() => {
       setDebouncedValue(searchText);
-    }, 200);
+    }, 300);
 
     return () => {
       clearTimeout(timer);
@@ -21,18 +21,20 @@ const Search = () => {
   }, [searchText]);
 
   useEffect(() => {
-    const get = async () => {
-      const result = await getSearchedMembers(debouncedValue);
-      if (selectedMembers.length > 0) {
-        const update = result.map((item: MemberProps) =>
-          selectedMembers.some((member) => member.memberId === item.memberId)
-            ? selectedMembers.find((member) => member.memberId === item.memberId)
-            : item,
-        );
-        setSearchedMembers(update);
-      } else setSearchedMembers(result);
-    };
-    get();
+    if (searchText) {
+      const get = async () => {
+        const result = await getSearchedMembers(debouncedValue);
+        if (selectedMembers.length > 0) {
+          const update = result.map((item: MemberProps) =>
+            selectedMembers.some((member) => member.memberId === item.memberId)
+              ? selectedMembers.find((member) => member.memberId === item.memberId)
+              : item,
+          );
+          setSearchedMembers(update);
+        } else setSearchedMembers(result);
+      };
+      get();
+    }
   }, [debouncedValue]);
 
   const onTextChange = (event: React.FormEvent<HTMLInputElement>) => {

--- a/src/components/Textarea/index.tsx
+++ b/src/components/Textarea/index.tsx
@@ -1,7 +1,23 @@
 import style from '@/components/Textarea/index.module.css';
+import { DebutGroupStore } from '@/store/store';
 
 const Textarea = () => {
-  return <textarea className={style.groupDescriptionTextarea}></textarea>;
+  const { debutGroup, setDebutGroupDescription } = DebutGroupStore();
+
+  const onTextareaChange = (e: React.FormEvent<HTMLTextAreaElement>) => {
+    const {
+      currentTarget: { value },
+    } = e;
+    setDebutGroupDescription(value);
+  };
+
+  return (
+    <textarea
+      className={style.groupDescriptionTextarea}
+      value={debutGroup.groupDescription}
+      onChange={onTextareaChange}
+    />
+  );
 };
 
 export default Textarea;

--- a/src/pages/debut.tsx
+++ b/src/pages/debut.tsx
@@ -1,14 +1,17 @@
 import Button from '@/components/Button';
 import DebutGroup from '@/components/DebutGroup';
 import { H1, H2 } from '@/components/Text';
+import { DebutGroupStore } from '@/store/store';
 
 const Debut = () => {
+  const { debutGroup } = DebutGroupStore();
+
   return (
     <div>
       <H2>데뷔를 축하합니다!</H2>
-      <H1>그룹명</H1>
+      <H1>{debutGroup.groupName}</H1>
       <DebutGroup />
-      <p>그룹설명</p>
+      <p>{debutGroup.groupDescription}</p>
       <Button fullWidth={true}>이미지로 저장하기</Button>
       <Button>다시 만들기</Button>
       <Button>공유하기</Button>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -29,6 +29,17 @@ interface SelectedMembersProps {
   setSelectedMembers: (members: MemberProps[]) => void;
 }
 
+interface DebutGroupProps {
+  debutGroup: {
+    groupMembers: MemberProps[];
+    groupName: string;
+    groupDescription: string;
+  };
+  setDebutGroupMembers: (members: MemberProps[]) => void;
+  setDebutGroupName: (input: string) => void;
+  setDebutGroupDescription: (description: string) => void;
+}
+
 export const MemberStore = create<MembersProps>()(
   devtools((set) => ({
     members: [],
@@ -49,5 +60,47 @@ export const SelectedMemberStore = create<SelectedMembersProps>()(
   devtools((set) => ({
     selectedMembers: [],
     setSelectedMembers: (members) => set({ selectedMembers: members }),
+  })),
+);
+
+export const DebutGroupStore = create<DebutGroupProps>()(
+  devtools((set) => ({
+    debutGroup: { groupName: '', groupMembers: [], groupDescription: '' },
+
+    setDebutGroupMembers: (members) =>
+      set((state) => {
+        const newState = {
+          debutGroup: {
+            groupMembers: members,
+            groupName: state.debutGroup.groupName,
+            groupDescription: state.debutGroup.groupDescription,
+          },
+        };
+        return newState;
+      }),
+
+    setDebutGroupName: (input: string) =>
+      set((state) => {
+        const newState = {
+          debutGroup: {
+            groupMembers: state.debutGroup.groupMembers,
+            groupName: input,
+            groupDescription: state.debutGroup.groupDescription,
+          },
+        };
+        return newState;
+      }),
+
+    setDebutGroupDescription: (description) =>
+      set((state) => {
+        const newState = {
+          debutGroup: {
+            groupMembers: state.debutGroup.groupMembers,
+            groupName: state.debutGroup.groupName,
+            groupDescription: description,
+          },
+        };
+        return newState;
+      }),
   })),
 );


### PR DESCRIPTION
## 📍 주요 변경사항

setting 페이지에서 `Input` 컴포넌트와 `Textarea` 컴포넌트에서 입력받은 값을 저장하고, `selectedMembers`를 복사하여 저장하는 `DebutGroupStore`를 생성하였습니다.


`DebutGroupStore`의 `groupMembers`는 각 프라퍼티의 id만 배열로 만들어 서버에 이미지를 요청할 예정입니다.
(받아온 이미지 url은 `groupMembers`에 포함되도록 업데이트할 예정)

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->