### PR TITLE
refactor: 무한스크롤, 멤버 선택기능 리팩토링

### DIFF
--- a/src/apis/getPageCount.ts
+++ b/src/apis/getPageCount.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { BASE_URL } from '@/constants/url';
+
+const getPageCount = async () => {
+  try {
+    const response = await axios.get(`${BASE_URL}/api/property?key=pageCount`);
+    return response.data;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export default getPageCount;

--- a/src/components/MemberCard/index.tsx
+++ b/src/components/MemberCard/index.tsx
@@ -4,47 +4,26 @@ import { T2, T5 } from '../Text';
 
 import style from '@/components/MemberCard/index.module.css';
 import { MemberProps, MemberStore, SearchedMemberStore, SelectedMemberStore } from '@/store/store';
+import select from '@/utils/select';
+import deselect from '@/utils/deselect';
 
 const MemberCard = ({ memberId, groupName, name, thumbnailImgUrl, isSelected }: MemberProps) => {
   const { members, setMembers } = MemberStore();
   const { selectedMembers, setSelectedMembers } = SelectedMemberStore();
   const { searchedMembers, setSearchedMembers } = SearchedMemberStore();
 
-  const handleSelect = (memberId: number) => {
-    const newMembers = [...members].map((item) =>
-      item.memberId === memberId ? { ...item, isSelected: !item.isSelected } : item,
-    );
-
-    const newSearchedMembers = [...searchedMembers].map((item) =>
-      item.memberId === memberId ? { ...item, isSelected: !item.isSelected } : item,
-    );
-
-    newMembers.forEach((item) =>
-      item.memberId === memberId ? setSelectedMembers([...selectedMembers, item]) : null,
-    );
-
-    setSearchedMembers(newSearchedMembers);
-    setMembers(newMembers);
-  };
-
-  const handleDeselect = (memberId: number) => {
-    const newMembers = [...members].map((item) =>
-      item.memberId === memberId ? { ...item, isSelected: !item.isSelected } : item,
-    );
-
-    const newSearchedMembers = [...searchedMembers].map((item) =>
-      item.memberId === memberId ? { ...item, isSelected: !item.isSelected } : item,
-    );
-
-    setSearchedMembers(newSearchedMembers);
-    setMembers(newMembers);
-
-    const newSelectedMembers = selectedMembers.filter((item) => item.memberId !== memberId);
-    setSelectedMembers(newSelectedMembers);
+  const params = {
+    memberId,
+    members,
+    setMembers,
+    selectedMembers,
+    setSelectedMembers,
+    searchedMembers,
+    setSearchedMembers,
   };
 
   const onMemberCardClick = () => {
-    isSelected ? handleDeselect(memberId) : handleSelect(memberId);
+    isSelected ? deselect(params) : select(params);
   };
 
   return (

--- a/src/components/SelectedMemberCard/index.tsx
+++ b/src/components/SelectedMemberCard/index.tsx
@@ -1,31 +1,28 @@
 import { T5 } from '../Text';
 
-import { MemberProps, MemberStore, SelectedMemberStore } from '@/store/store';
+import { MemberProps, MemberStore, SearchedMemberStore, SelectedMemberStore } from '@/store/store';
 import Close from '@/assets/close.svg';
+import deselect from '@/utils/deselect';
 
 const SelectedMemberCard = ({ name, memberId }: MemberProps) => {
   const { members, setMembers } = MemberStore();
   const { selectedMembers, setSelectedMembers } = SelectedMemberStore();
+  const { searchedMembers, setSearchedMembers } = SearchedMemberStore();
 
-  const handleDeselect = (memberId: number) => {
-    const selectUpdateMembers = [...members].map((item) => {
-      return item.memberId === memberId ? { ...item, isSelected: !item.isSelected } : item;
-    });
-
-    setMembers(selectUpdateMembers);
-
-    const newSelectedMembers = selectedMembers.filter((item) => item.memberId !== memberId);
-    setSelectedMembers(newSelectedMembers);
-  };
-
-  const onSelectedMemberCardClick = () => {
-    handleDeselect(memberId);
+  const params = {
+    memberId,
+    members,
+    setMembers,
+    selectedMembers,
+    setSelectedMembers,
+    searchedMembers,
+    setSearchedMembers,
   };
 
   return (
     <div
       className="flex justify-center items-center text-center bg-PRIMARY h-[30px] px-[12px] py-2 rounded-full whitespace-nowrap gap-1"
-      onClick={onSelectedMemberCardClick}
+      onClick={() => deselect(params)}
     >
       <T5 className="text-white">{name}</T5>
       <Close />

--- a/src/types/selectParams.ts
+++ b/src/types/selectParams.ts
@@ -1,0 +1,13 @@
+import { MemberProps } from '@/store/store';
+
+interface Params {
+  memberId: number;
+  members: MemberProps[];
+  setMembers: (item: MemberProps[]) => void;
+  selectedMembers: MemberProps[];
+  setSelectedMembers: (item: MemberProps[]) => void;
+  searchedMembers: MemberProps[];
+  setSearchedMembers: (item: MemberProps[]) => void;
+}
+
+export default Params;

--- a/src/utils/deselect.ts
+++ b/src/utils/deselect.ts
@@ -1,0 +1,27 @@
+import selectParams from '@/types/selectParams';
+
+const deselect = ({
+  memberId,
+  members,
+  setMembers,
+  selectedMembers,
+  setSelectedMembers,
+  searchedMembers,
+  setSearchedMembers,
+}: selectParams) => {
+  const newMembers = [...members].map((item) =>
+    item.memberId === memberId ? { ...item, isSelected: !item.isSelected } : item,
+  );
+
+  const newSearchedMembers = [...searchedMembers].map((item) =>
+    item.memberId === memberId ? { ...item, isSelected: !item.isSelected } : item,
+  );
+
+  setSearchedMembers(newSearchedMembers);
+  setMembers(newMembers);
+
+  const newSelectedMembers = selectedMembers.filter((item) => item.memberId !== memberId);
+  setSelectedMembers(newSelectedMembers);
+};
+
+export default deselect;

--- a/src/utils/select.ts
+++ b/src/utils/select.ts
@@ -1,0 +1,28 @@
+import selectParams from '@/types/selectParams';
+
+const select = ({
+  memberId,
+  members,
+  setMembers,
+  selectedMembers,
+  setSelectedMembers,
+  searchedMembers,
+  setSearchedMembers,
+}: selectParams) => {
+  const newMembers = [...members].map((item) =>
+    item.memberId === memberId ? { ...item, isSelected: !item.isSelected } : item,
+  );
+
+  const newSearchedMembers = [...searchedMembers].map((item) =>
+    item.memberId === memberId ? { ...item, isSelected: !item.isSelected } : item,
+  );
+
+  newMembers.forEach((item) =>
+    item.memberId === memberId ? setSelectedMembers([...selectedMembers, item]) : null,
+  );
+
+  setSearchedMembers(newSearchedMembers);
+  setMembers(newMembers);
+};
+
+export default select;


### PR DESCRIPTION
## 📍 주요 변경사항

무한스크롤 리팩토링 및 전체 페이지 수를 받는 api 연동하여 마지막 페이지 도달 시 추가 api 호출하지 않도록 수정하였습니다.
멤버 선택기능을 util함수로 분리하였습니다

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->