### PR TITLE
fix: 페이지 padding bottom을 crowd 높이만큼 설정

### DIFF
--- a/src/pages/debut.tsx
+++ b/src/pages/debut.tsx
@@ -18,6 +18,7 @@ const Debut: NextPage = () => {
   const [isReady, setIsReady] = useState(false);
   const canvas = useRef<HTMLCanvasElement>(null);
   const crowdRef = useRef<HTMLImageElement>(null);
+  const [crowdHeight, setCrowdHeight] = useState(0);
 
   useEffect(() => {
     setTimeout(() => {
@@ -69,7 +70,10 @@ const Debut: NextPage = () => {
       <Header title="데뷔">
         <ConfettiHandler />
       </Header>
-      <div className={`flex flex-col md:w-[50%] p-4 py-[68px] md:pb-[323px] md:items-center`}>
+      <div
+        className="flex flex-col md:w-[50%] p-4 py-[68px] md:items-center"
+        style={{ paddingBottom: `${crowdRef.current?.offsetHeight}px` }}
+      >
         <div className="w-full">
           <div className="flex bg-PRIMARY w-[86px] h-[20px] mb-1 rounded-full justify-center items-center">
             <T5 className="text-white">HOT DEBUT!</T5>


### PR DESCRIPTION
## 📍 주요 변경사항

데스크탑에서 debut 페이지 하단의 관중이미지가 버튼을 가려서 클릭이 불가능한 버그를 수정하였습니다.
관중이미지 높이만큼 하단 패딩을 주었어요

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->