### PR TITLE
fix: 세팅페이지 새로고침 시 데이터 없는 빈 화면 수정

### DIFF
--- a/src/pages/debut.tsx
+++ b/src/pages/debut.tsx
@@ -11,6 +11,7 @@ import postDebutMembers from '@/apis/postDebutMembers';
 import drawMembers from '@/utils/drawMembers';
 import sortCenter from '@/utils/sortCenter';
 import downloadImg from '@/utils/downloadImg';
+import updateLongImageUrl from '@/utils/updateLongImageUrl';
 
 const Debut: NextPage = () => {
   const [isLoading, setIsLoading] = useState(true);
@@ -18,34 +19,21 @@ const Debut: NextPage = () => {
   const [isReady, setIsReady] = useState(false);
   const canvas = useRef<HTMLCanvasElement>(null);
   const crowdRef = useRef<HTMLImageElement>(null);
-  const [crowdHeight, setCrowdHeight] = useState(0);
 
   useEffect(() => {
     setTimeout(() => {
       setIsLoading(false);
     }, 2000);
-  }, []);
-
-  useEffect(() => {
-    const DebutMembersIdList = debutGroup.groupMembers
-      .map((member) => member.memberId)
-      .sort((a, b) => a - b);
 
     const post = async () => {
-      const res = await postDebutMembers(DebutMembersIdList);
-      return res as MemberProps[];
+      const DebutMembersIdList = debutGroup.groupMembers
+        .map((member) => member.memberId)
+        .sort((a, b) => a - b);
+      return (await postDebutMembers(DebutMembersIdList)) as MemberProps[];
     };
 
     post()
-      .then((res) => {
-        const newGroupMembers = [...debutGroup.groupMembers];
-        res.forEach((member) => {
-          newGroupMembers.forEach((item) => {
-            member.memberId === item.memberId ? (item.longImageUrl = member.longImageUrl) : null;
-          });
-        });
-        return newGroupMembers;
-      })
+      .then((res) => updateLongImageUrl([...debutGroup.groupMembers], res))
       .then((newGroupMembers) => sortCenter(newGroupMembers, debutGroup.groupMembers.length))
       .then((sortedNewGroupMembers) => {
         setDebutGroupMembers(sortedNewGroupMembers);

--- a/src/pages/setting.tsx
+++ b/src/pages/setting.tsx
@@ -10,17 +10,20 @@ import { DebutGroupStore, SelectedMemberStore } from '@/store/store';
 import OrderedTitle from '@/components/OrderedTitle';
 import Header from '@/components/Header';
 import ModalHandler from '@/components/ModalHandler';
+import Modal from '@/components/Modal';
 
 const Setting: NextPage = () => {
   const { selectedMembers } = SelectedMemberStore();
   const { debutGroup, setDebutGroupMembers } = DebutGroupStore();
   const [isDisabled, setIsDisabled] = useState(true);
+  const [isEmpty, setIsEmpty] = useState(false);
 
   const handleClick = () => {
     setDebutGroupMembers([...selectedMembers]);
   };
 
   useEffect(() => {
+    if (selectedMembers.length === 0) setIsEmpty(true);
     const isCenterSelected = selectedMembers.some((item) => item.isCenter);
     const isPositionSelected = selectedMembers.every((item) => item.position);
     if (
@@ -37,6 +40,14 @@ const Setting: NextPage = () => {
 
   return (
     <>
+      {isEmpty ? (
+        <Modal
+          contents="잘못된 접근입니다."
+          handleModal={() => {
+            location.pathname = '/';
+          }}
+        />
+      ) : null}
       <Header title="그룹 설정">
         <ModalHandler
           contents={`데뷔를 위해서 모든 항목을 채워주세요 🙏\n\n한 포지션에는 한 멤버만 배정할 수 있습니다 🙋‍♀️\n\n센터는 그룹에서 한 명만 선택 가능합니다 ⭐️`}

--- a/src/utils/updateLongImageUrl.ts
+++ b/src/utils/updateLongImageUrl.ts
@@ -1,0 +1,12 @@
+import { MemberProps } from '@/store/store';
+
+const updateLongImageUrl = (prevData: MemberProps[], newData: MemberProps[]) => {
+  newData.forEach((member) => {
+    prevData.forEach((item) => {
+      member.memberId === item.memberId ? (item.longImageUrl = member.longImageUrl) : null;
+    });
+  });
+  return prevData;
+};
+
+export default updateLongImageUrl;


### PR DESCRIPTION
## 📍 주요 변경사항

새로고침 시 클라이언트 상태가 초기화되면서 세팅페이지와 데뷔페이지가 빈 화면으로 그려지고 있습니다.
데뷔페이지는 SSR 적용이 우선되어야 할 것 같아서 세팅페이지를 먼저 작업하였습니다.

새로고침하여 클라이언트 상태가 초기화되면 에러 모달을 발생시키며, 모달을 닫으면 곧바로 메인화면으로 이동합니다.

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->