### PR TITLE
feat: casting 페이지 스크롤 위치 로컬스토리지 저장

### DIFF
--- a/src/pages/casting.tsx
+++ b/src/pages/casting.tsx
@@ -7,20 +7,21 @@ import Search from '@/components/Search/index';
 import Button from '@/components/Button';
 import MemberCardList from '@/components/MemberCardList';
 import SelectedMemberCardList from '@/components/SelectedMemberCardList';
-import { MemberStore, SearchedMemberStore, SelectedMemberStore } from '@/store/store';
+import { SearchedMemberStore, SelectedMemberStore } from '@/store/store';
 import Header from '@/components/Header';
 import ModalHandler from '@/components/ModalHandler';
 import Seo from '@/components/Seo';
 
 const Casting: NextPage = () => {
   const { selectedMembers } = SelectedMemberStore();
-  const { setMembers } = MemberStore();
   const { setSearchedMembers } = SearchedMemberStore();
   const [isDisabled, setIsDisabled] = useState(true);
 
   useEffect(() => {
+    const scrollY = JSON.parse(localStorage.getItem('scrollY') as string);
+    if (scrollY !== '0') window.scrollTo(0, Number(scrollY));
+
     return () => {
-      setMembers([]);
       setSearchedMembers([]);
     };
   }, []);
@@ -45,7 +46,13 @@ const Casting: NextPage = () => {
         {selectedMembers.length ? <SelectedMemberCardList /> : null}
       </div>
       <Link href="/setting">
-        <Button isFixed={true} disabled={isDisabled}>
+        <Button
+          isFixed={true}
+          disabled={isDisabled}
+          onClick={() => {
+            localStorage.setItem('scrollY', JSON.stringify(window.scrollY));
+          }}
+        >
           <T2 className="text-white">
             {isDisabled ? '최소 2명 ~ 최대 10명을 선택해주세요' : '캐스팅 완료 👌'}
           </T2>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,36 +4,33 @@ import Link from 'next/link';
 
 import Button from '@/components/Button';
 import { H1, T2 } from '@/components/Text';
-import { DebutGroupStore, MemberStore, SelectedMemberStore } from '@/store/store';
+import { DebutGroupStore, SelectedMemberStore } from '@/store/store';
 import Seo from '@/components/Seo';
 
 const Home: NextPage = () => {
-  const { setMembers } = MemberStore();
   const { setSelectedMembers } = SelectedMemberStore();
-  const { setDebutGroupDescription, setDebutGroupMembers, setDebutGroupName } = DebutGroupStore();
+  const { setDebutGroup } = DebutGroupStore();
 
   useEffect(() => {
-    setMembers([]);
+    localStorage.removeItem('scrollY');
     setSelectedMembers([]);
-    setDebutGroupDescription('');
-    setDebutGroupName('');
-    setDebutGroupMembers([]);
+    setDebutGroup([], '', '');
   }, []);
 
   return (
     <div className="flex relative flex-col items-center h-full overflow-hidden">
       <Seo title="Home" />
       <img className="w-32 md:w-40 mt-[30%] md:mt-[10%]" src="images/logo.png" alt="로고" />
-      <H1>아이돌 메이커</H1>
-      {/* <p className="text-center my-6">
-        30년 간 꾸준한 덕질의 결실로
+      <H1>BeMyIdol</H1>
+      <T2 className="text-center my-6">
+        꾸준한 덕질의 결실로
         <br />
         ‘마스터 엔터테인먼트’의 CEO가 된 당신은
         <br />
         현존하는 최고의 아이돌 멤버들을 영입하여
         <br />
         아이돌 어벤져스를 만들 계획이다.
-      </p> */}
+      </T2>
       <Link href="/casting">
         <Button isWhite={true} isFixed={true}>
           <T2>걸그룹 만들러가기 🎀</T2>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -12,12 +12,6 @@ export interface MemberProps {
   position?: string;
 }
 
-interface MembersProps {
-  members: MemberProps[];
-  setMembers: (members: MemberProps[]) => void;
-  loadMembers: (members: MemberProps[]) => void;
-}
-
 interface SearchedMemberProps {
   searchedMembers: MemberProps[];
   setSearchedMembers: (searchedMembers: MemberProps[]) => void;
@@ -39,15 +33,6 @@ export interface DebutGroupProps {
   setDebutGroupName: (input: string) => void;
   setDebutGroupDescription: (description: string) => void;
 }
-
-export const MemberStore = create<MembersProps>()(
-  devtools((set) => ({
-    members: [],
-    setMembers: (members) => set({ members: members }),
-    loadMembers: (newMembers: MemberProps[]) =>
-      set((state) => ({ members: [...state.members, ...newMembers] })),
-  })),
-);
 
 export const SearchedMemberStore = create<SearchedMemberProps>()(
   devtools((set) => ({


### PR DESCRIPTION
## 📍 주요 변경사항

casting 페이지 스크롤 위치를 로컬스토리지에 저장하여 뒤로가기 시 해당 위치로 스크롤을 이동합니다

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->